### PR TITLE
close session in exception case

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -151,6 +151,7 @@ class Slave(threading.Thread):
         self.step = 0
         for i, point in enumerate(self.points):
             if not self.running:
+                session.close()
                 return
             logger.info('Visiting point %d (%s %s)', i, point[0], point[1])
             self.api.set_position(point[0], point[1], 0)
@@ -162,6 +163,7 @@ class Slave(threading.Thread):
                 cell_id=cell_ids
             )
             if response_dict is False:
+                session.close()
                 raise CannotProcessStep
             now = time.time()
             map_objects = response_dict['responses'].get('GET_MAP_OBJECTS', {})


### PR DESCRIPTION
Before: When the worker quit with "exception" or "not started" it kept the session alive until queuelimit