### PR TITLE
Added option to disable some of the workers

### DIFF
--- a/web.py
+++ b/web.py
@@ -5,14 +5,12 @@ import json
 
 import requests
 from flask import Flask, request, render_template
-from flask_googlemaps import GoogleMaps
-from flask_googlemaps import Map
-from flask_googlemaps import icons
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
-import config as app_config
+import config
 import db
 import utils
+from names import POKEMON_NAMES
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
@@ -20,23 +18,15 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 # Check whether config has all necessary attributes
 REQUIRED_SETTINGS = (
     'GRID',
+    'TRASH_IDS',
     'AREA_NAME',
     'REPORT_SINCE',
+    'SCAN_RADIUS',
 )
 for setting_name in REQUIRED_SETTINGS:
-    if not hasattr(app_config, setting_name):
+    if not hasattr(config, setting_name):
         raise RuntimeError('Please set "{}" in config'.format(setting_name))
 
-
-with open('credentials.json') as f:
-    credentials = json.load(f)
-
-with open('locales/pokemon.en.json') as f:
-    pokemon_names = json.load(f)
-
-
-GOOGLEMAPS_KEY = credentials.get('gmaps_key', None)
-AUTO_REFRESH = 45  # refresh map every X s
 
 
 def get_args():
@@ -61,13 +51,7 @@ def get_args():
     return parser.parse_args()
 
 
-def create_app():
-    app = Flask(__name__, template_folder='templates')
-    GoogleMaps(app, key=GOOGLEMAPS_KEY)
-    return app
-
-
-app = create_app()
+app = Flask(__name__, template_folder='templates')
 
 
 @app.route('/data')
@@ -77,28 +61,19 @@ def pokemon_data():
 
 @app.route('/workers_data')
 def workers_data():
-    return json.dumps(get_worker_markers())
-
-
-@app.route('/config')
-def config():
-    """Gets the settings for the Google Maps via REST"""
-    map_center = utils.get_map_center()
     return json.dumps({
-        'lat': map_center[0],
-        'lng': map_center[1],
-        'zoom': 15,
-        'identifier': 'fullmap'
+        'points': get_worker_markers(),
+        'scan_radius': config.SCAN_RADIUS,
     })
 
 
 @app.route('/')
 def fullmap():
+    map_center = utils.get_map_center()
     return render_template(
-        'map.html',
-        key=GOOGLEMAPS_KEY,
-        fullmap=get_map(),
-        auto_refresh=AUTO_REFRESH * 1000
+        'newmap.html',
+        area_name=config.AREA_NAME,
+        map_center=map_center,
     )
 
 
@@ -106,39 +81,35 @@ def get_pokemarkers():
     markers = []
     session = db.Session()
     pokemons = db.get_sightings(session)
+    forts = db.get_forts(session)
     session.close()
 
     for pokemon in pokemons:
-        name = pokemon_names[str(pokemon.pokemon_id)]
-        datestr = datetime.fromtimestamp(pokemon.expire_timestamp)
-        dateoutput = datestr.strftime("%H:%M:%S")
-
-        LABEL_TMPL = u'''
-<div><b>{name}</b><span> - </span><small><a href='http://www.pokemon.com/us/pokedex/{id}' target='_blank' title='View in Pokedex'>#{id}</a></small></div>
-<div>Disappears at - {disappear_time_formatted} <span class='label-countdown' disappears-at='{disappear_time}'></span></div>
-<div><a href='https://www.google.com/maps/dir/Current+Location/{lat},{lng}' target='_blank' title='View in Maps'>Get Directions</a></div>
-'''
-        label = LABEL_TMPL.format(
-            id=pokemon.pokemon_id,
-            name=name,
-            disappear_time=pokemon.expire_timestamp,
-            disappear_time_formatted=dateoutput,
-            lat=pokemon.lat,
-            lng=pokemon.lon,
-        )
-        #  NOTE: `infobox` field doesn't render multiple line string in frontend
-        label = label.replace('\n', '')
-
         markers.append({
+            'id': 'pokemon-{}'.format(pokemon.id),
             'type': 'pokemon',
-            'name': name,
-            'key': '{}-{}'.format(pokemon.pokemon_id, pokemon.spawn_id),
-            'disappear_time': pokemon.expire_timestamp,
-            'icon': 'static/icons/%d.png' % pokemon.pokemon_id,
-            'lat': pokemon.lat,
-            'lng': pokemon.lon,
+            'trash': pokemon.pokemon_id in config.TRASH_IDS,
+            'name': POKEMON_NAMES[pokemon.pokemon_id],
             'pokemon_id': pokemon.pokemon_id,
-            'infobox': label
+            'lat': pokemon.lat,
+            'lon': pokemon.lon,
+            'expires_at': pokemon.expire_timestamp,
+        })
+    for fort in forts:
+        if fort['guard_pokemon_id']:
+            pokemon_name = POKEMON_NAMES[fort['guard_pokemon_id']]
+        else:
+            pokemon_name = 'Empty'
+        markers.append({
+            'id': 'fort-{}'.format(fort['fort_id']),
+            'sighting_id': fort['id'],
+            'type': 'fort',
+            'prestige': fort['prestige'],
+            'pokemon_id': fort['guard_pokemon_id'],
+            'pokemon_name': pokemon_name,
+            'team': fort['team'],
+            'lat': fort['lat'],
+            'lon': fort['lon'],
         })
 
     return markers
@@ -150,51 +121,31 @@ def get_worker_markers():
     # Worker start points
     for worker_no, worker_points in enumerate(points):
         coords = utils.get_start_coords(worker_no)
-        if (not hasattr(app_config, 'DISABLE_MARKERS') or  worker_no not in app_config.DISABLE_MARKERS):
+        if (not hasattr(config, 'DISABLE_MARKERS') or  worker_no not in config.DISABLE_MARKERS):
             markers.append({
-                'icon': icons.dots.green,
                 'lat': coords[0],
-                'lng': coords[1],
-                'infobox': 'Worker %d' % worker_no,
-                'type': 'custom',
-                'subtype': 'worker',
-                'key': 'start-position-%d' % worker_no,
-                'disappear_time': -1
+                'lon': coords[1],
+                'type': 'worker',
+                'worker_no': worker_no,
             })
         else:
             markers.append({
-                'icon': icons.dots.red,
                 'lat': coords[0],
-                'lng': coords[1],
-                'infobox': 'Worker %d <br /> DISABLED' % worker_no,
-                'type': 'custom',
-                'subtype': 'worker',
-                'key': 'start-position-%d' % worker_no,
-                'disappear_time': -1
+                'lon': coords[1],
+                'type': 'worker',
+                'worker_no': worker_no,
             })
-        if (not hasattr(app_config, 'ENABLE_CIRCLES') or  worker_no in app_config.ENABLE_CIRCLES):
-            # Circles
+        # Circles
+        if (not hasattr(config, 'ENABLE_CIRCLES') or  worker_no in config.ENABLE_CIRCLES):
             for i, point in enumerate(worker_points):
                 markers.append({
                     'lat': point[0],
-                    'lng': point[1],
-                    'infobox': 'Worker %d point %d' % (worker_no, i),
-                    'subtype': 'point',
+                    'lon': point[1],
+                    'type': 'worker_point',
+                    'worker_no': worker_no,
+                    'point_no': i,
                 })
     return markers
-
-
-def get_map():
-    map_center = utils.get_map_center()
-    fullmap = Map(
-        identifier='fullmap2',
-        style='height:100%;width:100%;top:0;left:0;position:absolute;z-index:200;',
-        lat=map_center[0],
-        lng=map_center[1],
-        markers=[],  # will be fetched by browser
-        zoom='15',
-    )
-    return fullmap
 
 
 @app.route('/report')
@@ -212,12 +163,12 @@ def report_main():
     js_data = {
         'charts_data': {
             'punchcard': db.get_punch_card(session),
-            'top30': [(pokemon_names[str(r[0])], r[1]) for r in top_pokemon],
+            'top30': [(POKEMON_NAMES[r[0]], r[1]) for r in top_pokemon],
             'bottom30': [
-                (pokemon_names[str(r[0])], r[1]) for r in bottom_pokemon
+                (POKEMON_NAMES[r[0]], r[1]) for r in bottom_pokemon
             ],
             'stage2': [
-                (pokemon_names[str(r[0])], r[1]) for r in stage2_pokemon
+                (POKEMON_NAMES[r[0]], r[1]) for r in stage2_pokemon
             ],
         },
         'maps_data': {
@@ -228,11 +179,11 @@ def report_main():
         'zoom': 13,
     }
     icons = {
-        'top30': [(r[0], pokemon_names[str(r[0])]) for r in top_pokemon],
-        'bottom30': [(r[0], pokemon_names[str(r[0])]) for r in bottom_pokemon],
-        'stage2': [(r[0], pokemon_names[str(r[0])]) for r in stage2_pokemon],
+        'top30': [(r[0], POKEMON_NAMES[r[0]]) for r in top_pokemon],
+        'bottom30': [(r[0], POKEMON_NAMES[r[0]]) for r in bottom_pokemon],
+        'stage2': [(r[0], POKEMON_NAMES[r[0]]) for r in stage2_pokemon],
         'nonexistent': [
-            (r, pokemon_names[str(r)])
+            (r, POKEMON_NAMES[r])
             for r in db.get_nonexistent_pokemon(session)
         ]
     }
@@ -244,7 +195,7 @@ def report_main():
     return render_template(
         'report.html',
         current_date=datetime.now(),
-        area_name=app_config.AREA_NAME,
+        area_name=config.AREA_NAME,
         area_size=area,
         total_spawn_count=session_stats['count'],
         spawns_per_hour=session_stats['per_hour'],
@@ -253,6 +204,7 @@ def report_main():
         session_length_hours=int(session_stats['length_hours']),
         js_data=js_data,
         icons=icons,
+        google_maps_key=config.GOOGLE_MAPS_KEY,
     )
 
 
@@ -271,14 +223,15 @@ def report_single(pokemon_id):
     return render_template(
         'report_single.html',
         current_date=datetime.now(),
-        area_name=app_config.AREA_NAME,
+        area_name=config.AREA_NAME,
         area_size=utils.get_scan_area(),
         pokemon_id=pokemon_id,
-        pokemon_name=pokemon_names[str(pokemon_id)],
+        pokemon_name=POKEMON_NAMES[pokemon_id],
         total_spawn_count=db.get_total_spawns_count(session, pokemon_id),
         session_start=session_stats['start'],
         session_end=session_stats['end'],
         session_length_hours=int(session_stats['length_hours']),
+        google_maps_key=config.GOOGLE_MAPS_KEY,
         js_data=js_data,
     )
 

--- a/web.py
+++ b/web.py
@@ -150,24 +150,37 @@ def get_worker_markers():
     # Worker start points
     for worker_no, worker_points in enumerate(points):
         coords = utils.get_start_coords(worker_no)
-        markers.append({
-            'icon': icons.dots.green,
-            'lat': coords[0],
-            'lng': coords[1],
-            'infobox': 'Worker %d' % worker_no,
-            'type': 'custom',
-            'subtype': 'worker',
-            'key': 'start-position-%d' % worker_no,
-            'disappear_time': -1
-        })
-        # Circles
-        for i, point in enumerate(worker_points):
+        if (not hasattr(app_config, 'DISABLE_MARKERS') or  worker_no not in app_config.DISABLE_MARKERS):
             markers.append({
-                'lat': point[0],
-                'lng': point[1],
-                'infobox': 'Worker %d point %d' % (worker_no, i),
-                'subtype': 'point',
+                'icon': icons.dots.green,
+                'lat': coords[0],
+                'lng': coords[1],
+                'infobox': 'Worker %d' % worker_no,
+                'type': 'custom',
+                'subtype': 'worker',
+                'key': 'start-position-%d' % worker_no,
+                'disappear_time': -1
             })
+        else:
+            markers.append({
+                'icon': icons.dots.red,
+                'lat': coords[0],
+                'lng': coords[1],
+                'infobox': 'Worker %d <br /> DISABLED' % worker_no,
+                'type': 'custom',
+                'subtype': 'worker',
+                'key': 'start-position-%d' % worker_no,
+                'disappear_time': -1
+            })
+        if (not hasattr(app_config, 'ENABLE_CIRCLES') or  worker_no in app_config.ENABLE_CIRCLES):
+            # Circles
+            for i, point in enumerate(worker_points):
+                markers.append({
+                    'lat': point[0],
+                    'lng': point[1],
+                    'infobox': 'Worker %d point %d' % (worker_no, i),
+                    'subtype': 'point',
+                })
     return markers
 
 

--- a/worker.py
+++ b/worker.py
@@ -233,6 +233,11 @@ class Slave(threading.Thread):
         self.error_code = 'KILLED'
         self.running = False
 
+    def disable(self):
+        """Marks worker as disabled"""
+        self.error_code = 'DISABLED'
+        self.running = False
+
 
 def get_status_message(workers, count, start_time, points_stats):
     messages = [workers[i].status.ljust(20) for i in range(count)]
@@ -251,7 +256,7 @@ def get_status_message(workers, count, start_time, points_stats):
         '',
     ]
     previous = 0
-    for i in range(4, count + 4, 4):
+    for i in range(5, count + 5, 5):
         output.append('\t'.join(messages[previous:i]))
         previous = i
     return '\n'.join(output)
@@ -264,8 +269,11 @@ def start_worker(worker_no, points):
         worker_no=worker_no,
         points=points
     )
-    worker.daemon = True
-    worker.start()
+    if (not hasattr(config, 'DISABLE_MARKERS') or worker_no not in config.DISABLE_MARKERS):
+        worker.daemon = True
+        worker.start()
+    else:
+        worker.disable()
     workers[worker_no] = worker
 
 

--- a/worker.py
+++ b/worker.py
@@ -22,13 +22,14 @@ import utils
 # Check whether config has all necessary attributes
 REQUIRED_SETTINGS = (
     'DB_ENGINE',
+    'ENCRYPT_PATH',
     'CYCLES_PER_WORKER',
     'MAP_START',
     'MAP_END',
     'GRID',
     'ACCOUNTS',
-    'LAT_GAIN',
-    'LON_GAIN',
+    'SCAN_RADIUS',
+    'SCAN_DELAY',
 )
 for setting_name in REQUIRED_SETTINGS:
     if not hasattr(config, setting_name):
@@ -50,7 +51,7 @@ def configure_logger(filename='worker.log'):
             '[%(asctime)s][%(threadName)10s][%(levelname)8s][L%(lineno)4d] '
             '%(message)s'
         ),
-        style='{',
+        style='%',
         level=logging.INFO,
     )
 
@@ -80,6 +81,7 @@ class Slave(threading.Thread):
         self.running = True
         center = self.points[0]
         self.api = PGoApi()
+        self.api.activate_signature(config.ENCRYPT_PATH)
         self.api.set_position(center[0], center[1], 100)  # lat, lon, alt
 
     def run(self):
@@ -93,11 +95,15 @@ class Slave(threading.Thread):
         service = config.ACCOUNTS[self.worker_no][2]
         while True:
             try:
-                self.api.login(
+                loginsuccess = self.api.login(
                     provider=service,
                     username=config.ACCOUNTS[self.worker_no][0],
                     password=config.ACCOUNTS[self.worker_no][1],
                 )
+                if not loginsuccess:
+                    self.error_code = 'LOGIN FAIL'
+                    self.restart()
+                    return
             except pgoapi_exceptions.AuthException:
                 self.error_code = 'LOGIN FAIL'
                 self.restart()
@@ -165,9 +171,9 @@ class Slave(threading.Thread):
             )
             if response_dict is False:
                 raise CannotProcessStep
-            now = time.time()
             map_objects = response_dict['responses'].get('GET_MAP_OBJECTS', {})
             pokemons = []
+            forts = []
             if map_objects.get('status') == 1:
                 for map_cell in map_objects['map_cells']:
                     for pokemon in map_cell.get('wild_pokemons', []):
@@ -176,18 +182,37 @@ class Slave(threading.Thread):
                         # time_till_hidden is below 15 min
                         if pokemon['time_till_hidden_ms'] < 0:
                             continue
-                        pokemons.append(self.normalize_pokemon(pokemon, now))
+                        pokemons.append(
+                            self.normalize_pokemon(
+                                pokemon, map_cell['current_timestamp_ms']
+                            )
+                        )
+                    for fort in map_cell.get('forts', []):
+                        if not fort.get('enabled'):
+                            continue
+                        if fort.get('type') == 1:  # probably pokestops
+                            continue
+                        forts.append(self.normalize_fort(fort))
             for raw_pokemon in pokemons:
                 db.add_sighting(session, raw_pokemon)
                 self.seen_per_cycle += 1
                 self.total_seen += 1
-            logger.info('Point processed, %d Pokemons seen!', len(pokemons))
             session.commit()
+            for raw_fort in forts:
+                db.add_fort_sighting(session, raw_fort)
+            # Commit is not necessary here, it's done by add_fort_sighting
+            logger.info(
+                'Point processed, %d Pokemons and %d forts seen!',
+                len(pokemons),
+                len(forts),
+            )
             # Clear error code and let know that there are Pokemon
             if self.error_code and self.seen_per_cycle:
                 self.error_code = None
             self.step += 1
-            time.sleep(random.uniform(5, 7))
+            time.sleep(
+                random.uniform(config.SCAN_DELAY, config.SCAN_DELAY + 2)
+            )
         session.close()
         if self.seen_per_cycle == 0:
             self.error_code = 'NO POKEMON'
@@ -199,9 +224,21 @@ class Slave(threading.Thread):
             'encounter_id': raw['encounter_id'],
             'spawn_id': raw['spawn_point_id'],
             'pokemon_id': raw['pokemon_data']['pokemon_id'],
-            'expire_timestamp': now + raw['time_till_hidden_ms'] / 1000.0,
+            'expire_timestamp': (now + raw['time_till_hidden_ms']) / 1000.0,
             'lat': raw['latitude'],
             'lon': raw['longitude'],
+        }
+
+    @staticmethod
+    def normalize_fort(raw):
+        return {
+            'external_id': raw['id'],
+            'lat': raw['latitude'],
+            'lon': raw['longitude'],
+            'team': raw.get('owned_by_team', 0),
+            'prestige': raw.get('gym_points', 0),
+            'guard_pokemon_id': raw.get('guard_pokemon_id', 0),
+            'last_modified': raw['last_modified_timestamp_ms'] / 1000.0,
         }
 
     @property
@@ -276,7 +313,6 @@ def start_worker(worker_no, points):
         worker.disable()
     workers[worker_no] = worker
 
-
 def spawn_workers(workers, status_bar=True):
     points = utils.get_points_per_worker()
     start_date = datetime.now()
@@ -299,7 +335,7 @@ def spawn_workers(workers, status_bar=True):
         now = time.time()
         # Clean cache
         if now - last_cleaned_cache > (15 * 60):  # clean cache
-            db.CACHE.clean_expired()
+            db.SIGHTING_CACHE.clean_expired()
             last_cleaned_cache = now
         # Check up on workers
         if now - last_workers_checked > (5 * 60):
@@ -319,7 +355,7 @@ def spawn_workers(workers, status_bar=True):
                 _ = os.system('cls')
             else:
                 _ = os.system('clear')
-            print get_status_message(workers, count, start_date, points_stats)
+            print(get_status_message(workers, count, start_date, points_stats))
         time.sleep(0.5)
 
 


### PR DESCRIPTION
This commit will add an option to disable some workers in config file (for example - if they are scanning forest area, with no pokemon spawns in there).

Also it will allow to display "circles" on the map for only chosen workers (also in config file), to make sure that "Show workers" might work also for those with over 100+ workers.

New config variables:
DISABLE_MARKERS = [0, 1, 2]
ENABLE_CIRCLES = [5,8,15]

Because of my city have some irregular shape, a lot of workers were scanning low populated or forest areas, that's because of the rectangle grid shape. After disabling almost half of the workers, I noticed a huge decrease at CPU usage :)
![pokeminer_worker](https://cloud.githubusercontent.com/assets/3898985/17301011/3bc81e7e-5815-11e6-9b23-d2450ffa1cfc.jpg)

And this is the web result:
![pokeminer_web](https://cloud.githubusercontent.com/assets/3898985/17301010/3bc32414-5815-11e6-9a9e-3fb52d70e836.jpg)

Hope you'll find it useful 