### PR TITLE
Added web hook support

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -27,5 +27,5 @@ STAGE2 = [94, 139, 141, 149]
 REPORT_SINCE = datetime(2016, 7, 29)
 GOOGLE_MAPS_KEY = 's3cr3t'
 
-# Comma-separated list of web hook endpoints. E.g. ['http://webhook1.com', 'http://webhook2.com']
+# Comma-separated list of webhook endpoints. E.g. ['http://webhook1.com', 'http://webhook2.com']
 WEBHOOK_ENDPOINTS = []

--- a/config.py.example
+++ b/config.py.example
@@ -26,3 +26,6 @@ STAGE2 = [94, 139, 141, 149]
 
 REPORT_SINCE = datetime(2016, 7, 29)
 GOOGLE_MAPS_KEY = 's3cr3t'
+
+# Comma-separated list of web hook endpoints. E.g. ['http://webhook1.com', 'http://webhook2.com']
+WEBHOOK_ENDPOINTS = []

--- a/worker.py
+++ b/worker.py
@@ -204,7 +204,6 @@ class Slave(threading.Thread):
                             'last_modified_time': pokemon['last_modified_timestamp_ms'],
                             'time_until_hidden_ms': pokemon['time_till_hidden_ms']
                         }
-                        logger.info(webhook_data)
                         self.send_to_webhook('pokemon', webhook_data)
                     for fort in map_cell.get('forts', []):
                         if not fort.get('enabled'):

--- a/worker.py
+++ b/worker.py
@@ -190,7 +190,7 @@ class Slave(threading.Thread):
                                 pokemon, map_cell['current_timestamp_ms']
                             )
                         )
-                        # Prepare and send the pokemon data to the web hook listeners
+                        # Prepare and send the pokemon data to the webhook listeners
                         d_t = datetime.utcfromtimestamp(
                             (pokemon['last_modified_timestamp_ms'] +
                              pokemon['time_till_hidden_ms']) / 1000.0)
@@ -237,7 +237,7 @@ class Slave(threading.Thread):
 
     @staticmethod
     def send_to_webhook(message_type, message):
-        """Sends the Pokemon data to each subscribing web hook endpoit"""
+        """Sends the Pokemon data to each subscribing webhook endpoit"""
         data = {
             'type': message_type,
             'message': message


### PR DESCRIPTION
This pull request adds support for an arbitrary number of webhook endpoints to work with Pokeminer. I did my best to match the overall structure of your code.

The data structure of data sent to the listeners is identical to that used by PokemonGo-Map, so it will be instantly compatible with any webhook listener built by 3rd-parties for PGM.

I tested this by using it with two http://requestb.in/ endpoints and Pokelyzer, running the scan with two accounts. It successfully posted its results to all three endpoints.

Webhook endpoints are included in the config.py file through a list of strings, where each string represents one endpoint.

The only additional libraries required in the `worker.py` file were "requests" (which is already in the requirements.txt file), the native base 64 encoder, and the native calendar package for timestamp conversion.
