### PR TITLE
Allow configuration of SCAN_DELAY bounds

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -10,8 +10,7 @@ MAP_START = (12.3456, 34.5678)
 MAP_END = (13.4567, 35.6789)
 GRID = (2, 2)  # row, column
 CYCLES_PER_WORKER = 3
-SCAN_DELAY_LOW = 10  # seconds
-SCAN_DELAY_HIGH = 12  # will vary between SCAN_DELAY_LOW and SCAN_DELAY_HIGH
+SCAN_DELAY = (10, 12)  # will vary between these values (in seconds)
 
 SCAN_RADIUS = 70  # metres
 

--- a/config.py.example
+++ b/config.py.example
@@ -10,7 +10,8 @@ MAP_START = (12.3456, 34.5678)
 MAP_END = (13.4567, 35.6789)
 GRID = (2, 2)  # row, column
 CYCLES_PER_WORKER = 3
-SCAN_DELAY = 10  # seconds
+SCAN_DELAY_LOW = 10  # seconds
+SCAN_DELAY_HIGH = 12  # will vary between SCAN_DELAY_LOW and SCAN_DELAY_HIGH
 
 SCAN_RADIUS = 70  # metres
 

--- a/worker.py
+++ b/worker.py
@@ -29,8 +29,7 @@ REQUIRED_SETTINGS = (
     'GRID',
     'ACCOUNTS',
     'SCAN_RADIUS',
-    'SCAN_DELAY_LOW',
-    'SCAN_DELAY_HIGH'
+    'SCAN_DELAY'
 )
 for setting_name in REQUIRED_SETTINGS:
     if not hasattr(config, setting_name):
@@ -211,9 +210,12 @@ class Slave(threading.Thread):
             if self.error_code and self.seen_per_cycle:
                 self.error_code = None
             self.step += 1
-            time.sleep(
-                random.uniform(config.SCAN_DELAY_LOW, config.SCAN_DELAY_HIGH)
-            )
+            if isinstance(config.SCAN_DELAY, tuple):
+                time.sleep(random.uniform(*config.SCAN_DELAY))
+            else:
+                time.sleep(
+                    random.uniform(config.SCAN_DELAY, config.SCAN_DELAY + 2)
+                )
         session.close()
         if self.seen_per_cycle == 0:
             self.error_code = 'NO POKEMON'

--- a/worker.py
+++ b/worker.py
@@ -29,7 +29,8 @@ REQUIRED_SETTINGS = (
     'GRID',
     'ACCOUNTS',
     'SCAN_RADIUS',
-    'SCAN_DELAY',
+    'SCAN_DELAY_LOW',
+    'SCAN_DELAY_HIGH'
 )
 for setting_name in REQUIRED_SETTINGS:
     if not hasattr(config, setting_name):
@@ -211,7 +212,7 @@ class Slave(threading.Thread):
                 self.error_code = None
             self.step += 1
             time.sleep(
-                random.uniform(config.SCAN_DELAY, config.SCAN_DELAY + 2)
+                random.uniform(config.SCAN_DELAY_LOW, config.SCAN_DELAY_HIGH)
             )
         session.close()
         if self.seen_per_cycle == 0:


### PR DESCRIPTION
Some people may want to experiment with ranges other than `SCAN_DELAY+2`, so this would allow configuring that through _config.py_. Users trying different ranges could also reduce detectability.
