### PR TITLE
Allow using proxies for API requests

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -11,6 +11,7 @@ MAP_END = (13.4567, 35.6789)
 GRID = (2, 2)  # row, column
 CYCLES_PER_WORKER = 3
 SCAN_DELAY = 10  # seconds
+PROXIES = None  # Insert dictionary with 'http' and 'https' keys to enable
 
 SCAN_RADIUS = 70  # metres
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ gpsoauth==0.3.0
 coveralls==1.1
 werkzeug==0.11.10
 sqlalchemy==1.0.14
--e git+https://github.com/keyphact/pgoapi.git@06eaef1e0353d17f775f2d1765d6281a05be7654#egg=pgoapi
+-e git+https://github.com/keyphact/pgoapi.git@39ea20d31b770dd7bc83180d60283e171090e16d#egg=pgoapi
 enum34==1.1.6

--- a/worker.py
+++ b/worker.py
@@ -83,6 +83,8 @@ class Slave(threading.Thread):
         self.api = PGoApi()
         self.api.activate_signature(config.ENCRYPT_PATH)
         self.api.set_position(center[0], center[1], 100)  # lat, lon, alt
+        if hasattr(config, 'PROXIES') and config.PROXIES:
+            self.api.set_proxy(config.PROXIES)
 
     def run(self):
         """Wrapper for self.main - runs it a few times before restarting


### PR DESCRIPTION
Add option for proxies, bump API version for proxy compatibility.

config example:
```python
PROXIES = {
    'http': 'socks5://127.0.0.1:1080',
    'https': 'socks5://127.0.0.1:1080'
}
```