### PR TITLE
WIP: Improve scantime

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -15,6 +15,12 @@ PROXIES = None  # Insert dictionary with 'http' and 'https' keys to enable
 
 SCAN_RADIUS = 70  # metres
 
+
+# Higher value, fewer scanpoints are necessary, however there's obviously
+# a lower cap and the runtime increases exponentially, so don't set it
+# much higher
+SAMPLES_PER_POINT = 5 
+
 ACCOUNTS = [
     ('ash_ketchum', 'pik4chu', 'ptc'),
     ('ziemniak_kalafior', 'ogorek', 'google'),

--- a/db.py
+++ b/db.py
@@ -426,3 +426,26 @@ def get_all_spawn_coords(session, pokemon_id=None):
     if config.REPORT_SINCE:
         points = points.filter(Sighting.expire_timestamp > get_since())
     return points.all()
+
+def get_known_spawnpoints(session):
+    query = ('''
+        SELECT lat, lon
+        FROM sightings
+        WHERE
+            lat >= {lat_start} AND 
+            lat <= {lat_end} AND
+            lon >= {lon_start} AND
+            lon <= {lon_end}
+        GROUP BY spawn_id;
+    '''.format(
+        lat_end=config.MAP_START[0],
+        lat_start=config.MAP_END[0],
+        lon_start=config.MAP_START[1],
+        lon_end=config.MAP_END[1]
+    ))
+    query = session.execute(query)
+    results = []
+    for x in query.fetchall():
+        results.append((float(x[0]), float(x[1])))
+    return results
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ werkzeug==0.11.10
 sqlalchemy==1.0.14
 -e git+https://github.com/keyphact/pgoapi.git@39ea20d31b770dd7bc83180d60283e171090e16d#egg=pgoapi
 enum34==1.1.6
+intervaltree==2.1.0

--- a/utils.py
+++ b/utils.py
@@ -94,53 +94,18 @@ def map_point(interval_point, circles):
     lat = point['x']
     point['circles'] = [circle[2] for circle in circles[lat] if inside_radius(circle[2], point)]
 
-    #list(filter(lambda circle, point=point: (point in circle['inside']), circles))
-
     return Interval(interval_begin, interval_end, point)
 
-def asdf(circles, points):
+def map_points_to_circles(circles, points):
     newCircles = []
     meh = 0
     circles = IntervalTree(map(lambda interval_circle, points=points: map_circle(interval_circle, points), circles))
-    ##circles = list(filter(lambda circle: circle['insideCount']>0, circles))
 
     points = IntervalTree(map(lambda point, circles=circles: map_point(point,circles),points))
 
     print('circles generated')
     
-    #for interval_circle in circles:
-    #    intval_begin = interval_circle[0]
-    #    intval_end = interval_circle[1]
-    #    circle = interval_circle[2]
-
-    #    lat = circle['x']
-    #    circle['inside'] = [pt[2] for pt in points[lat] if inside_radius(circle, pt[2])]
-
-    #    # add circle to list of circles which cover the point
-    #    for pt in circle['inside']:
-    #        pt['circles'].append(circle)
-
-    #    # set #points which are in the circle
-    #    circle['insideCount'] = len(circle['inside'])
-
-    #    interval_circle = Interval(intval_begin, intval_end, circle)
-    #    
     return (circles, points)
-
-    #for circle in circles:
-    #  circle['inside'] = []
-    #  circle['insideCount'] = 0
-    #  for point in points:
-    #      if inside_radius(circle, point):
-    #          circle['inside'].append(point)
-    #          circle['insideCount'] += 1
-    #          point['circles'].append(circle)
-    #  if len(circle['inside']) > 0:
-    #      newCircles.append(circle)
-    #  meh = meh + 1
-    #  if meh % 100== 0:
-    #      print(meh)
-    #return(newCircles, points)
 
 def insert_point_into_tree(point, interval):
 
@@ -185,35 +150,13 @@ def calculate_minimal_pointset(spawn_points):
             dist = distance.distance((x,y), point).meters
             if dist > 70:
                 print('wtf???')
-            #circles.append(a_circle)
 
             interval_of_circles = insert_point_into_tree(a_circle, interval_of_circles)
 
         
 
-    circles = []
-
-    
-    #for point in spawn_points:
-    #    for i in range(0, config.SAMPLES_PER_POINT):
-    #        r = random.uniform(0,radius)
-    #        bearing = random.uniform(0, 359)
-    #        
-    #        origin = Point(point[0], point[1])
-    #        destination = distance.distance(meters=r).destination(origin, bearing)
-    #        
-    #        lat2, lon2 = destination.latitude, destination.longitude
-
-
-    #        #x = point[0] + r * math.cos(fi))
-    #        #y = point[1] + r * math.sin(fi)
-    #        x = lat2
-    #        y = lon2
-    #        circles.append({'x':x,'y':y, 'insideCount':0})
-    # done
-
     print('circles generated')
-    foo = asdf(interval_of_circles, interval_of_points)
+    foo = map_points_to_circles(interval_of_circles, interval_of_points)
     print('distances calculated')
     circles = foo[0]
     points = foo[1]
@@ -223,24 +166,11 @@ def calculate_minimal_pointset(spawn_points):
     print('sample circles: ' +str(len(circles)))
     new_circles = []
     countt = 0
-    meh = 0
-    #circles=list(circles)
-    #all_points = list(points)
     while True:
-      meh += 1
       # get circle with max insideCount
-      #circle = circles[0]
       circle = max(circles, key=lambda circle: circle[2]['insideCount'])[2]
-      #for i in range(0, len(circles)):
-      #    if circle['insideCount'] < circles[i]['insideCount']:
-      #        circle = circles[i]
       anything = False
       for point in circle['inside']:
-          #all_points = [pt for pt in spawn_points if pt != point]
-          #for circle in circles:
-          #    circle['inside'] = [pt for pt in spawn_points if pt != point]
-          #    circle['insideCount'] -= 1
-
           if not point['covered']:
               anything = True
               point['covered'] = True
@@ -248,18 +178,8 @@ def calculate_minimal_pointset(spawn_points):
               
               for circle_b in point['circles']:
                   circle_b['insideCount'] -= 1
-      #for j in range(0, len(circle['inside'])):
-      #   if not circle['inside'][j]['covered']:
-      #       anything = True
-      #       circle['inside'][j]['covered'] = True
-      #       countt += 1
-      #       
-      #       for k in range(0, len(circle['inside'][j])):
-      #           circle['inside'][j]['circles'][k]['insideCount'] -=1
       if anything:
           new_circles.append(circle)
-      #if not all_points:
-      #    break
       if(countt == len(points)):
           break
     circles = new_circles
@@ -279,23 +199,19 @@ def calculate_minimal_pointset(spawn_points):
             
     print('done, amount circles: ' + str(len(circles)))
 
-    points = [[] for _ in range(total_workers)]
-    points = [
-        sort_points_for_worker(p, i)
-        for i, p in enumerate(points)
-    ]
     points = list(map(lambda circle: (circle['x'], circle['y']),circles))
 
     # slice list into
     total_workers = config.GRID[0] * config.GRID[1]
-    n = len(points) / total_workers + 1
+    n = int(len(points)/total_workers + 1)
     points = [points[i:i + n] for i in range(0, len(points), n)]
 
     # and sort the points for each worker
     points = [
         sort_points_for_worker(p, i)
         for i, p in enumerate(points)
-    ]
+    ] 
+    print(points)
     return points
 
 
@@ -365,4 +281,4 @@ def sort_points_for_worker(points, worker_no):
 
 
 def get_distance(p1, p2):
-    return math.sqrt(pow(p1['x'] - p2['x'], 2) + pow(p1['y'] - p2['y'], 2))
+    return math.sqrt(pow(p1[0] - p2[0], 2) + pow(p1[1] - p2[1], 2)) 

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,7 @@
 import math
 from geopy import distance, Point
+from intervaltree import Interval, IntervalTree
+
 
 import config
 
@@ -69,6 +71,169 @@ def get_gains():
     return abs(start.latitude - lat_gain), abs(start.longitude - lon_gain)
 
 
+
+
+def map_circle(circle, points):
+    circle['inside'] = list(filter(lambda point: inside_radius(circle, point), points))
+    circle['insideCount'] = len(circle['inside'])
+    return circle
+
+def map_point(point, circles):
+        point['circles'] = list(filter(lambda circle, point=point: (point in circle['inside']), circles))
+        return point
+
+def asdf(circles, points):
+    newCircles = []
+    meh = 0
+    circles = list(map(lambda circle, points=points: map_circle(circle, points), circles))
+    circles = list(filter(lambda circle: circle['insideCount']>0, circles))
+
+    points = list(map(lambda point, circles=circles: map_point(point,circles),points))
+
+    print('circles generated')
+    
+    
+    return (circles, points)
+
+    #for circle in circles:
+    #  circle['inside'] = []
+    #  circle['insideCount'] = 0
+    #  for point in points:
+    #      if inside_radius(circle, point):
+    #          circle['inside'].append(point)
+    #          circle['insideCount'] += 1
+    #          point['circles'].append(circle)
+    #  if len(circle['inside']) > 0:
+    #      newCircles.append(circle)
+    #  meh = meh + 1
+    #  if meh % 100== 0:
+    #      print(meh)
+    #return(newCircles, points)
+
+def insert_point_into_tree(point, interval):
+    origin = Point(point[0], point[1])
+    lat_begin = distance.distance(meters=70).destination(origin, 0).latitude
+    lat_end = distance.distance(meters=-70).destination(origin, 0).latitude
+    interval_of_points[lat_begin:lat_end] = {'x':point[0],'y':point[1], 'covered': False,'circles':[]}
+    return interval
+
+
+
+def calculate_minimal_pointset(spawn_points):
+    points = []
+    interval_of_points = IntervalTree()
+    for point in spawn_points:
+        p = {'x':point[0],'y':point[1], 'covered': False,'circles':[]}
+        points.append(p)
+        interval_of_points = insert_point_into_tree(p)
+
+        
+    import math
+    import random
+
+    circles = []
+    radius = config.SCAN_RADIUS-20
+    for point in spawn_points:
+        for i in range(0, config.SAMPLES_PER_POINT):
+            r = random.uniform(0,radius)
+            bearing = random.uniform(0, 359)
+            
+            origin = Point(point[0], point[1])
+            destination = distance.distance(meters=r).destination(origin, bearing)
+            
+            lat2, lon2 = destination.latitude, destination.longitude
+
+
+            #x = point[0] + r * math.cos(fi))
+            #y = point[1] + r * math.sin(fi)
+            x = lat2
+            y = lon2
+            circles.append({'x':x,'y':y, 'insideCount':0})
+    # done
+    print('circles generated')
+    foo = asdf(circles, points)
+    print('distances calculated')
+    circles = foo[0]
+    points = foo[1]
+    
+    
+    print('points: ' +str(len(points)))
+    print('sample circles: ' +str(len(circles)))
+    new_circles = []
+    countt = 0
+    meh = 0
+    while True:
+      meh += 1
+      # get circle with max insideCount
+      #circle = circles[0]
+      circle = max(circles, key=lambda circle: circle['insideCount'])
+      #for i in range(0, len(circles)):
+      #    if circle['insideCount'] < circles[i]['insideCount']:
+      #        circle = circles[i]
+      anything = False
+      for point in circle['inside']:
+          if not point['covered']:
+              anything = True
+              point['covered'] = True
+              countt += 1
+              
+              for circle in point['circles']:
+                  circle['insideCount'] -= 1
+      #for j in range(0, len(circle['inside'])):
+      #   if not circle['inside'][j]['covered']:
+      #       anything = True
+      #       circle['inside'][j]['covered'] = True
+      #       countt += 1
+      #       
+      #       for k in range(0, len(circle['inside'][j])):
+      #           circle['inside'][j]['circles'][k]['insideCount'] -=1
+      if anything:
+          new_circles.append(circle)
+      if(countt == len(points)):
+          break
+      print(abs(countt-len(points)))
+      if(meh % 1000 == 0):
+          print('meh: ' + str(meh))
+    circles = new_circles
+    print('one last check')
+    for point in points:
+        inside = False
+        for circle in point['circles']:
+            if distance.distance((point['x'],point['y']), (circle['x'], circle['y'])).meters <= 70:
+                inside = True
+        if not inside:
+            print('##################################')
+            print('LONELY POINT FOUND:')
+            print(point)
+            print('##################################')
+            
+    print('done, amount circles: ' + str(len(circles)))
+    return [list(map(lambda circle: (circle['x'], circle['y']),circles))]
+
+
+
+
+def inside_radius(p1, p2):
+    #return distance.great_circle((p1['x'], p1['y']), (p2['x'],p2['y'])).meters <= config.SCAN_RADIUS
+    return haversine(p1['x'], p1['y'], p2['x'],p2['y']) <= (config.SCAN_RADIUS-5)
+
+from math import radians, cos, sin, asin, sqrt
+def haversine(lon1, lat1, lon2, lat2):
+    """
+    Calculate the great circle distance between two points 
+    on the earth (specified in decimal degrees)
+    """
+    # convert decimal degrees to radians 
+    lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
+    # haversine formula 
+    dlon = lon2 - lon1 
+    dlat = lat2 - lat1 
+    a = sin(dlat/2)**2 + cos(lat1) * cos(lat2) * sin(dlon/2)**2
+    c = 2 * asin(sqrt(a)) 
+    km = 6367 * c
+    return km*1000
+
+
 def get_points_per_worker():
     """Returns all points that should be visited for whole grid"""
     total_workers = config.GRID[0] * config.GRID[1]
@@ -112,4 +277,4 @@ def sort_points_for_worker(points, worker_no):
 
 
 def get_distance(p1, p2):
-    return math.sqrt(pow(p1[0] - p2[0], 2) + pow(p1[1] - p2[1], 2))
+    return math.sqrt(pow(p1['x'] - p2['x'], 2) + pow(p1['y'] - p2['y'], 2))

--- a/utils.py
+++ b/utils.py
@@ -281,4 +281,4 @@ def sort_points_for_worker(points, worker_no):
 
 
 def get_distance(p1, p2):
-    return math.sqrt(pow(p1[0] - p2[0], 2) + pow(p1[1] - p2[1], 2)) 
+    return math.sqrt(pow(p1[0] - p2[0], 2) + pow(p1[1] - p2[1], 2))

--- a/web.py
+++ b/web.py
@@ -116,8 +116,13 @@ def get_pokemarkers():
 
 
 def get_worker_markers():
+    import db
+    spawn_points = db.get_known_spawnpoints(db.Session())
+    spawn_points = utils.calculate_minimal_pointset(spawn_points)
+
     markers = []
-    points = utils.get_points_per_worker()
+    #points = utils.get_points_per_worker()
+    points = spawn_points
     # Worker start points
     for worker_no, worker_points in enumerate(points):
         coords = utils.get_start_coords(worker_no)

--- a/worker.py
+++ b/worker.py
@@ -310,7 +310,8 @@ def start_worker(worker_no, points):
 
 
 def spawn_workers(workers, status_bar=True):
-    points = utils.get_points_per_worker()
+    spawn_points = db.get_known_spawnpoints(db.Session())
+    points = utils.calculate_minimal_pointset(spawn_points)
     start_date = datetime.now()
     count = config.GRID[0] * config.GRID[1]
     for worker_no in range(count):


### PR DESCRIPTION
Reduce the scan time by calculating a set of scan points which covers all distinct spawns. This leads to a reduced amount of points to scan without missing a single pokemon.

As the title states, it's still work in progress. What's missing at this point:
-a **proper** integration into the worker cycle, so that it makes a 2 hours session every 24 hours in which it makes an extensive scan sweep to detect possible changes in spawn points. Right now there are no sweeps and nothing, it just directly starts with the reduced set
- a setting in which one can inform the program if the area already has been scanned(so that it can already start with the reduced scan point set)
