### PR TITLE
Start scan from current point after restart, soft-ban detection, and a shutdown function on banned

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ gpsoauth==0.3.0
 coveralls==1.1
 werkzeug==0.11.10
 sqlalchemy==1.0.14
--e git+https://github.com/keyphact/pgoapi.git@39ea20d31b770dd7bc83180d60283e171090e16d#egg=pgoapi
+-e git+https://github.com/keyphact/pgoapi.git@60096ccfea0a97e5358be1d32283ebbfb853b00a#egg=pgoapi
 enum34==1.1.6

--- a/worker.py
+++ b/worker.py
@@ -86,7 +86,7 @@ class Slave(threading.Thread):
         self.banned_count = 0
         self.error_code = None
         self.running = True
-        self.active = False
+        self.active = True
         center = self.points[0]
         self.api = PGoApi()
         self.api.activate_signature(config.ENCRYPT_PATH)

--- a/worker.py
+++ b/worker.py
@@ -339,7 +339,6 @@ class Slave(threading.Thread):
         self.error_code = 'SHUTDOWN'
         self.active = False
 
-
 def get_status_message(workers, count, start_time, points_stats):
     messages = [workers[i].status.ljust(20) for i in range(count)]
     running_for = datetime.now() - start_time


### PR DESCRIPTION
Soft-ban could be detected when get_map_objects response only have current_timestamp and cell_id, which will make a point processed without any pokemon and fort found. By counting how many times forts  result is empty, we could find out when a worker is banned. Right now worker thread will be terminated (I use word shutdown) when it get banned. 

MalformedResponse exception currently is not in use. I put a try-except block when assign value of response_dict to map_objects and handle the TypeError exception. 

I did this because response_dict have a Nonetype when "server is busy or offline" and in this situation I think it's better if worker simply move to the next point and try to send another request rather than restart itself.  There is also "sequence index must be integer, not 'str'" error, happen when worker considered not logged in by pgoapi. Worker need an immediate restart and relogin on this error.

For now I just put banned_count in the try-except block to shutdown the worker if it keep getting TypeError. It's better to create a counter and count how many times this TypeError happen, especially sequence index error, and raise MalformedResponse to restart worker when it reach the limit.